### PR TITLE
fix: regenerate session ID after login to prevent session fixation (CWE-384)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2171,6 +2171,7 @@ def login():
         password = request.form.get("password", "")
         if _const_eq(username, AUTH_USERNAME) and _const_eq(password, AUTH_PASSWORD):
             session.clear()
+            session["_sid"] = os.urandom(16).hex()
             session.permanent = True
             session["authenticated"] = True
             return redirect(_safe_next_path(request.args.get("next")))


### PR DESCRIPTION
## Summary

Session Fixation (CWE-384): The /login endpoint calls session.clear() which only removes session data but does NOT issue a new session cookie. An attacker who sets a victim's session cookie before login can hijack the authenticated session afterwards.

## Fix

Added session["_sid"] = os.urandom(16).hex() after session.clear() to force cookie rotation — this changes the session content, which changes the signed cookie value, effectively regenerating the session identifier.

## Understanding This Vulnerability

### What is it?
Session Fixation: an attacker fixes a session ID before authentication, the victim logs in with that ID, and the attacker gains access to the victim's session.

### Why does it matter?
Critical for any app with authentication. It bypasses all account protections — 2FA, passwords, biometrics. This is why OWASP mandates session regeneration on login.

### When does it occur?
(1) login handler doesn't call session_regenerate_id()/forget(), (2) session accepted from URL parameter, (3) no IP/User-Agent binding.

### How to fix properly?
1. Call forget()/session_regenerate_id() BEFORE remember()/set_user()
2. Invalidate session on logout
3. Bind session to fingerprint (IP + User-Agent)

### Analogy
Like a coat check ticket. If you can take ticket #42, give it to a VIP, then come back and say 'I'm #42, give me the VIP's coat' — that's session fixation. Regeneration = new ticket every time.

### References
- https://owasp.org/www-community/attacks/Session_fixation
- https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html

---
Found by [GSC](https://github.com/poliakarmai/gsc) — understand code, don't just accept it.